### PR TITLE
Replace workspaceRoot with workspaceFolder

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -281,7 +281,7 @@ Then add the block below to your `launch.json` file and put it inside the `.vsco
     "type": "chrome",
     "request": "launch",
     "url": "http://localhost:3000",
-    "webRoot": "${workspaceRoot}/src",
+    "webRoot": "${workspaceFolder}",
     "sourceMapPathOverrides": {
       "webpack:///src/*": "${webRoot}/*"
     }


### PR DESCRIPTION
Updated VS Code launch.json configuration settings so that interactive debugging can be initiated from the debugger menu.

The variable workspaceRoot has been deprecated in favor of workspaceFolder, as per the VS Code website:
https://code.visualstudio.com/docs/editor/variables-reference
>Q: Why isn't ${workspaceRoot} documented?
>A: The variable ${workspaceRoot} was deprecated in favor of ${workspaceFolder} to better align with Multi-root Workspace support.

I confirmed the new configuration as you can see in the screenshot.

![image](https://user-images.githubusercontent.com/1802850/43621382-ff2ef2fa-968b-11e8-96d7-fc1876c6955d.png)

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
